### PR TITLE
Add Bower package definition

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "fit.js",
+  "main": "fit.js",
+  "version": "0.1.0",
+  "homepage": "http://soulwire.github.io/fit.js/",
+  "authors": [
+    "Justin Windle <justin@soulwire.co.uk>"
+  ],
+  "description": "Fit things into other things",
+  "keywords": [
+    "fit",
+    "things"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Add support for fit.js to be included as a Bower front-end package. See
http://bower.io for more info. Create bower.json file that defines the
package. Once committed to master, the package can be registered officially
with Bower by running the following command (with bower installed):

bower register fit.js https://github.com/soulwire/fit.js.git
