### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "fit.js",
   "main": "fit.js",
-  "version": "0.1.0",
   "homepage": "http://soulwire.github.io/fit.js/",
   "authors": [
     "Justin Windle <justin@soulwire.co.uk>"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property